### PR TITLE
Fix Badge Positioning

### DIFF
--- a/StyleSheets/bexBadgesIFStudios.css
+++ b/StyleSheets/bexBadgesIFStudios.css
@@ -24,7 +24,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -36,7 +36,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -48,7 +48,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -60,7 +60,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -72,7 +72,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }

--- a/StyleSheets/bexBadgestssnStyle.css
+++ b/StyleSheets/bexBadgestssnStyle.css
@@ -14,7 +14,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -31,7 +31,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -43,7 +43,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -55,7 +55,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -67,7 +67,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }

--- a/StyleSheets/bexStyle.css
+++ b/StyleSheets/bexStyle.css
@@ -5,7 +5,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -22,7 +22,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -34,7 +34,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -46,7 +46,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -58,7 +58,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }

--- a/StyleSheets/styleTwitch.css
+++ b/StyleSheets/styleTwitch.css
@@ -5,7 +5,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -22,7 +22,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -34,7 +34,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -45,7 +45,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -57,7 +57,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -69,7 +69,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }

--- a/StyleSheets/twitchbadgesIFStudios.css
+++ b/StyleSheets/twitchbadgesIFStudios.css
@@ -24,7 +24,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -36,7 +36,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -48,7 +48,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -60,7 +60,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -72,7 +72,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }

--- a/StyleSheets/twitchbadgesStyle.css
+++ b/StyleSheets/twitchbadgesStyle.css
@@ -5,7 +5,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -22,7 +22,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -34,7 +34,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -46,7 +46,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -58,7 +58,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }

--- a/StyleSheets/twitchbadgestssnStyle.css
+++ b/StyleSheets/twitchbadgestssnStyle.css
@@ -14,7 +14,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -31,7 +31,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -43,7 +43,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -55,7 +55,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }
@@ -67,7 +67,7 @@
     padding-top: 7.5px;
     background-size: 23px 23px;
     font-size: 15px;
-    background-position: 0px;
+    background-position: 0px 8px;
     border-left: 3px solid transparent;
     border-right: 3px solid transparent;
 }


### PR DESCRIPTION
Because of a lack of positioning horizontally for the badges in the various stylesheets, the browser renders the background image at 0 50%. I've applied a static fix that will put the badges back on the initial first line that they should be on.