### PR TITLE
Added Greasemonkey Userscript for Beam Extended

### DIFF
--- a/Bookmark/bexForGreasemonkey.user.js
+++ b/Bookmark/bexForGreasemonkey.user.js
@@ -1,0 +1,17 @@
+// ==UserScript==
+// @name        Beam Extended
+// @namespace   http://beamalerts.com/bex/
+// @description This extension will expand the potential of the smaller channels on beam.pro. Offers custom channel emotes, supports all twitch emotes + our own custom emotes, twitch/custom badges and changing direct image links into images. 
+// @author      Vexatos / ExuDev
+// @homepage    http://beamalerts.com/bex/
+// @icon        https://raw.githubusercontent.com/ExuDev/BeamExtended/master/icons/icon.png
+// @downloadURL https://raw.githubusercontent.com/ExuDev/BeamExtended/master/Bookmark/bexForGreasemonkey.user.js
+// @updateURL   https://raw.githubusercontent.com/ExuDev/BeamExtended/master/Bookmark/bexForGreasemonkey.user.js
+// @encoding    utf-8
+// @include     http*://*beam.pro*
+// @version     1.0.0
+// @run-at      document-end
+// @grant       none
+// ==/UserScript==
+
+$.getScript('https://raw.githubusercontent.com/ExuDev/BeamExtended/master/Bookmark/bexForBookmark.js')();


### PR DESCRIPTION
This simple [Greasemonkey](https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/) script will, when installed, automatically execute bexForBookmark.js.
Users having Greasemonkey installed will, given the raw URL (https://raw.githubusercontent.com/ExuDev/BeamExtended/master/Bookmark/bexForGreasemonkey.user.js) be able to install it by clicking that link.

Description is copied from the Chrome Extension.

This is a nice and easy temporary solution for Mozilla Firefox users. If merged, I'd recommend putting a link containing the direct URL on the website so people having Greasemonkey can simply click that to install it (Greasemonkey will automatically detect that this is a Greasemonkey script).